### PR TITLE
Drop unneeded typedef for openal

### DIFF
--- a/src/friend.h
+++ b/src/friend.h
@@ -9,7 +9,6 @@
 typedef struct edit_change EDIT_CHANGE;
 typedef struct file_transfer FILE_TRANSFER;
 typedef uint8_t *UTOX_IMAGE;
-typedef unsigned int ALuint;
 
 typedef struct friend_meta_data {
     uint8_t version;
@@ -71,7 +70,7 @@ typedef struct utox_friend {
     /* Audio / Video */
     int32_t  call_state_self, call_state_friend;
     uint16_t video_width, video_height;
-    ALuint   audio_dest;
+    unsigned audio_dest;
 
     /* File transfers */
     bool     ft_autoaccept;

--- a/src/groups.h
+++ b/src/groups.h
@@ -3,7 +3,6 @@
 
 #include "messages.h"
 
-typedef unsigned int ALuint;
 typedef struct edit_change EDIT_CHANGE;
 
 #define MAX_GROUP_PEERS 256
@@ -31,8 +30,8 @@ typedef struct groupchat {
 
     GNOTIFY_TYPE notify;
 
-    bool   muted;
-    ALuint audio_dest;
+    bool     muted;
+    unsigned audio_dest;
 
     char     name[128];
     uint16_t name_length;


### PR DESCRIPTION
We're planning to replace openal, and/or we don't want to maintain that